### PR TITLE
Fixed bug in array responses

### DIFF
--- a/lib/schoolfinder/response.rb
+++ b/lib/schoolfinder/response.rb
@@ -4,7 +4,7 @@ module Schoolfinder
     attr_accessor :body
     
     def initialize(response)
-      self.body = rash_response(response)
+      rash_response(response)
       if self.body.respond_to?('fault_string')
         raise Schoolfinder::Error.new(self.body.fault_code, self.body.fault_string)
       end

--- a/spec/schoolfinder/client_spec.rb
+++ b/spec/schoolfinder/client_spec.rb
@@ -16,6 +16,7 @@ describe "Schoolfinder::Client" do
       @response = @schoolfinder.school_search(:zip => "29601")
       @response.should_not be_nil
       @response.body.should be_kind_of(Array)
+      @response.body.first.should be_kind_of(Hashie::Rash)
     end
   end
   
@@ -30,6 +31,7 @@ describe "Schoolfinder::Client" do
       @response = @schoolfinder.test_rating(:nces_id => "061029001146")
       @response.should_not be_nil
       @response.body.should be_kind_of(Array)
+      @response.body.first.should be_kind_of(Hashie::Rash)
     end
   end
   
@@ -114,6 +116,7 @@ describe "Schoolfinder::Client" do
       @response = @schoolfinder.number_of("Greenville", "SC")
       @response.should_not be_nil
       @response.body.should be_kind_of(Array)
+      @response.body.first.should be_kind_of(Hashie::Rash)
     end
   end
   
@@ -128,6 +131,7 @@ describe "Schoolfinder::Client" do
       @response = @schoolfinder.district_search(:city => "Greenville", :state => "SC")
       @response.should_not be_nil
       @response.body.should be_kind_of(Array)
+      @response.body.first.should be_kind_of(Hashie::Rash)
     end
   end
   


### PR DESCRIPTION
Fixing response to return Hashie::Rash objects for all items in an array of results, instead of an array of hashes.
